### PR TITLE
Fix typo in error message

### DIFF
--- a/lib/rules/no-argument-spread.js
+++ b/lib/rules/no-argument-spread.js
@@ -22,7 +22,7 @@ module.exports = {
     schema: [], // Add a schema if the rule has options
     messages: {
       spreadAsArgs:
-        "Don't use the spread opertor for arguments. It can lead to a stack overflow.",
+        "Don't use the spread operator for arguments. It can lead to a stack overflow.",
     },
   },
 


### PR DESCRIPTION
"opertor" -> "operator"